### PR TITLE
Rename GitHub repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openrm/node-hato-sentry.git"
+    "url": "git+https://github.com/openrm/hato-sentry.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/openrm/node-hato-sentry/issues"
+    "url": "https://github.com/openrm/hato-sentry/issues"
   },
-  "homepage": "https://github.com/openrm/node-hato-sentry#readme",
+  "homepage": "https://github.com/openrm/hato-sentry#readme",
   "peerDependencies": {
     "hato": "git+https://github.com/openrm/hato.git"
   },


### PR DESCRIPTION
I was thinking about this yesterday. The name is a bit confusing, if we write something for another language it can be under another name IMO.

I was even thinking of `hato-plugin-sentry` but I'm not sure.

Would like to hear your thoughts :pray: 